### PR TITLE
getSuggestions() will not working correctly with different languages …

### DIFF
--- a/Did you mean functionality with Laravel Scout.md
+++ b/Did you mean functionality with Laravel Scout.md
@@ -319,7 +319,7 @@ class CityController extends Controller
     public function getSuggestions(Request $request)
     {
         $TNTIndexer = new TNTIndexer;
-        $trigrams   = $TNTIndexer->buildTrigrams($request->get('city'));
+        $trigrams   = utf8_encode($TNTIndexer->buildTrigrams($request->get('city')));
 
         $tnt = new TNTSearch;
 


### PR DESCRIPTION
…without encode to utf8

Thank's for article. But i have small improvement - getSuggestions() method will not working correctly with different languages without encode to utf8, thus...
```
$trigrams   = $TNTIndexer->buildTrigrams($request->get('city'));
```

```
$trigrams   = utf8_encode($TNTIndexer->buildTrigrams($request->get('city')));
```